### PR TITLE
Improvements to Analytics gathering

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/activities/DSOActivity.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/activities/DSOActivity.java
@@ -2,13 +2,14 @@ package com.mozilla.hackathon.kiboko.activities;
 
 import android.support.v7.app.AppCompatActivity;
 
+import com.mozilla.hackathon.kiboko.Analytics;
 import com.mozilla.hackathon.kiboko.App;
 import com.mozilla.hackathon.kiboko.events.ApplicationStateChanged;
 import com.mozilla.hackathon.kiboko.services.DataBootstrapService;
 import com.squareup.otto.Bus;
 
 /**
- * Created by Brian Mwadime on 06/06/2016.
+ * Created by secretrobotron in July of 2016.
  */
 public class DSOActivity extends AppCompatActivity {
 
@@ -22,7 +23,8 @@ public class DSOActivity extends AppCompatActivity {
 
         App.getBus().post(new ApplicationStateChanged(true));
         super.onResume();
-        System.out.println("Resume");
+
+        Analytics.add("Resumed DSO Activity", this.getClass().getSimpleName());
     }
 
     @Override
@@ -31,6 +33,5 @@ public class DSOActivity extends AppCompatActivity {
         App.getBus().post(new ApplicationStateChanged(false));
         bus.unregister(this);
         super.onPause();
-        System.out.println("Pause");
     }
 }

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/activities/ResultActivity.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/activities/ResultActivity.java
@@ -8,6 +8,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
+import com.mozilla.hackathon.kiboko.Analytics;
 import com.mozilla.hackathon.kiboko.R;
 
 import pl.droidsonroids.gif.GifImageView;
@@ -34,8 +35,10 @@ public class ResultActivity extends AppCompatActivity {
         TextView txtPoints = (TextView) findViewById(R.id.quizResult);
         //get score
         Bundle b = getIntent().getExtras();
-        int score= b.getInt("score");
+        int score = b.getInt("score");
         txtPoints.setText(getString(R.string.quiz_template_points, score));
+
+        Analytics.add("Icon Quiz Finished", new Integer(score).toString());
 
         GifImageView gifImageView = (GifImageView) findViewById((R.id.result_image));
         int randomIndex = new Double(Math.random() * imageResources.length).intValue();
@@ -54,6 +57,7 @@ public class ResultActivity extends AppCompatActivity {
     }
 
     public void playAgain(View view){
+        Analytics.add("Icon Quiz Play Again");
         Intent intent = new Intent(ResultActivity.this, IconQuizActivity.class);
         startActivity(intent);
         finish();

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/activities/TutorialSlideActivity.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/activities/TutorialSlideActivity.java
@@ -21,6 +21,7 @@ import android.widget.TextView;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.mozilla.hackathon.kiboko.Analytics;
 import com.mozilla.hackathon.kiboko.R;
 import com.mozilla.hackathon.kiboko.fragments.ScreenSlidePageFragment;
 import com.mozilla.hackathon.kiboko.models.Step;
@@ -94,6 +95,8 @@ public class TutorialSlideActivity extends DSOActivity implements LoaderManager.
                     mNext.setEnabled(true);
                     mPrev.setEnabled(false);
                 }
+
+                Analytics.add("Tutorial Slide", mTopic + ", " + new Integer(mPager.getCurrentItem()).toString());
             }
         });
 
@@ -107,6 +110,8 @@ public class TutorialSlideActivity extends DSOActivity implements LoaderManager.
                     mNext.setEnabled(false);
                     mPrev.setEnabled(true);
                 }
+
+                Analytics.add("Tutorial Slide", mTopic + ", " + new Integer(mPager.getCurrentItem()).toString());
             }
         });
 
@@ -158,6 +163,8 @@ public class TutorialSlideActivity extends DSOActivity implements LoaderManager.
                 mTopic = (String)intent.getExtras().get("topic");
             }
         }
+
+        Analytics.add("Tutorial Slide", mTopic);
     }
 
     @Override

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/adapters/IconsAdapter.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/adapters/IconsAdapter.java
@@ -11,6 +11,7 @@ import android.widget.Filterable;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.mozilla.hackathon.kiboko.Analytics;
 import com.mozilla.hackathon.kiboko.R;
 import com.mozilla.hackathon.kiboko.models.IconTopic;
 
@@ -116,6 +117,7 @@ public class IconsAdapter extends BaseAdapter implements Filterable {
 //                    }
 //                });
                 tooltip.show();
+                Analytics.add("Icon List icon clicked", topic.getTag());
             }
         });
 


### PR DESCRIPTION
1. Permissions in manifest to write to external storage.
2. Analytics in more/better places.
3. Write to external storage instead.
4. Limits size of analytics file to 100KB.

Fixes #87.