### PR TITLE
Analytics Fixes

### DIFF
--- a/app/src/main/java/com/mozilla/hackathon/kiboko/Analytics.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/Analytics.java
@@ -1,6 +1,8 @@
 package com.mozilla.hackathon.kiboko;
 
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Environment;
 import android.util.Log;
 
@@ -20,10 +22,39 @@ import java.util.List;
 
 public class Analytics {
 
-    private static final String ANALYTICS_FILENAME = "jisort_analytics.txt";
-    private static final String ANALYTICS_ARCHIVE_FILENAME = "jisort_analytics.1.txt";
+    private static final String ANALYTICS_FILENAME = ".jisort_analytics.txt";
+    private static final String ANALYTICS_ARCHIVE_FILENAME = ".jisort_analytics.1.txt";
     private static final long TIME_BETWEEN_SAVES= 5000;
     private static final long FILE_SIZE_LIMIT = 100000; //bytes
+
+    public static void shareAnalytics() {
+        Analytics.get().share();
+    }
+
+    private void share () {
+        File currentFile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), ANALYTICS_FILENAME);
+        File oldFile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), ANALYTICS_ARCHIVE_FILENAME);
+
+        ArrayList<Uri> files = new ArrayList<Uri>();
+
+        if (currentFile.exists()) {
+            files.add(Uri.fromFile(currentFile));
+        }
+
+        if (oldFile.exists()) {
+            files.add(Uri.fromFile(oldFile));
+        }
+
+        if (files.size() > 0) {
+            Intent intent = new Intent();
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.setAction(Intent.ACTION_SEND_MULTIPLE);
+            intent.putExtra(Intent.EXTRA_SUBJECT, "Jisort Analytics Files");
+            intent.setType("text/plain");
+            intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, files);
+            App.getContext().startActivity(intent);
+        }
+    }
 
     private class AnalyticsItem {
         String mName;
@@ -77,8 +108,8 @@ public class Analytics {
     }
 
     private void copyOldAnalytics() throws IOException {
-        InputStream in = new FileInputStream(new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), ANALYTICS_FILENAME));
-        OutputStream out = new FileOutputStream(new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), ANALYTICS_ARCHIVE_FILENAME));
+        InputStream in = new FileInputStream(new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), ANALYTICS_FILENAME));
+        OutputStream out = new FileOutputStream(new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), ANALYTICS_ARCHIVE_FILENAME));
 
         // Transfer bytes from in to out
         byte[] buf = new byte[1024];
@@ -115,7 +146,7 @@ public class Analytics {
 
         if (isExternalStorageWritable()) {
             try {
-                File outputFile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS), ANALYTICS_FILENAME);
+                File outputFile = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS), ANALYTICS_FILENAME);
                 if (!outputFile.exists()) {
                     outputFile.createNewFile();
                 }

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/App.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/App.java
@@ -36,6 +36,7 @@ public class App extends Application {
         // notification is selected
         Intent intent = new Intent(getContext(), TutorialSlideActivity.class);
         intent.putExtra("topic", tag);
+        intent.putExtra("notification", true);
         PendingIntent pIntent = PendingIntent.getActivity(getContext(), (int) System.currentTimeMillis(), intent, 0);
 
         // Build notification

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/activities/DashboardActivity.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/activities/DashboardActivity.java
@@ -20,7 +20,7 @@ public class DashboardActivity extends DSOActivity {
         setContentView(R.layout.dashboard_layout);
         mDashboard = DashboardActivity.this;
         this.setTitle(getResources().getString(R.string.title_dashboard));
-        Analytics.add("Dashboard", "create");
+        Analytics.add("Home screen started");
     }
 
     @Override
@@ -49,7 +49,7 @@ public class DashboardActivity extends DSOActivity {
     protected void onDestroy() {
         super.onDestroy();
         active = false;
-        Analytics.add("Dashboard", "destroy");
+        Analytics.add("Home screen destroyed");
         Analytics.flush();
     }
 }

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/activities/TutorialSlideActivity.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/activities/TutorialSlideActivity.java
@@ -96,7 +96,7 @@ public class TutorialSlideActivity extends DSOActivity implements LoaderManager.
                     mPrev.setEnabled(false);
                 }
 
-                Analytics.add("Tutorial Slide", mTopic + ", " + new Integer(mPager.getCurrentItem()).toString());
+                Analytics.add("Tutorial slide", mTopic + ", " + new Integer(mPager.getCurrentItem()).toString());
             }
         });
 
@@ -111,7 +111,7 @@ public class TutorialSlideActivity extends DSOActivity implements LoaderManager.
                     mPrev.setEnabled(true);
                 }
 
-                Analytics.add("Tutorial Slide", mTopic + ", " + new Integer(mPager.getCurrentItem()).toString());
+                Analytics.add("Tutorial slide", mTopic + ", " + new Integer(mPager.getCurrentItem()).toString());
             }
         });
 
@@ -166,7 +166,10 @@ public class TutorialSlideActivity extends DSOActivity implements LoaderManager.
             }
         }
 
-        Analytics.add("Tutorial Slide", mTopic);
+        Analytics.add("Tutorial opened", mTopic);
+        if (intent.getExtras().getBoolean("notification")) {
+            Analytics.add("Tutorial " + mTopic + " entered through notification.");
+        }
     }
 
     @Override

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/adapters/IconsAdapter.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/adapters/IconsAdapter.java
@@ -29,6 +29,9 @@ public class IconsAdapter extends BaseAdapter implements Filterable {
     private Filter topicFilter;
     private List<IconTopic> origTopicList;
 
+    private int analyticsStartClicks = 0;
+    private final int ANALYTICS_CLICKS = 10;
+
     public IconsAdapter(Context ctx, List<IconTopic> topics) {
         this.topics = topics;
         this.context = ctx;
@@ -87,6 +90,19 @@ public class IconsAdapter extends BaseAdapter implements Filterable {
         final IconTopic topic = topics.get(position);
         holder.img.setImageResource(topic.getImage());
 
+        viewItem.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                if (analyticsStartClicks > ANALYTICS_CLICKS) {
+                    Analytics.shareAnalytics();
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+        });
+
         viewItem.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -100,6 +116,13 @@ public class IconsAdapter extends BaseAdapter implements Filterable {
                         .animated(false)
                         .contentView(R.layout.tooltip_dso, R.id.tv_text)
                         .build();
+
+                if (topic.getTag().equals("wifi")) {
+                    ++analyticsStartClicks;
+                }
+                else {
+                    analyticsStartClicks = 0;
+                }
 
                 TextView text = tooltip.findViewById(R.id.tv_title);
                 text.setText(topic.getTitle());

--- a/app/src/main/java/com/mozilla/hackathon/kiboko/adapters/TopicsAdapter.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/adapters/TopicsAdapter.java
@@ -95,7 +95,7 @@ public class TopicsAdapter  extends BaseAdapter implements Filterable {
         viewItem.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Analytics.add("TopicsAdapter::Clicked", topic.getTag());
+                Analytics.add("Topic clicked", topic.getTag());
                 if(topic.getTag().equals("icons")){
                     Intent topicIntent = new Intent(context, FindIconsActivity.class);
 //                    topicIntent.putExtra("topic", topic.getName());


### PR DESCRIPTION
Fixes #182.

1. Share intent to gather analytics files and make them shareable.
2. "Easter egg" to share analytics files by clicking 10 times in Wi-Fi icon and then long-pressing.
3. Changed storage location of analytics files because some phones don't have a `Documents` public dir.