### PR TITLE
Removed registration for battery receiver.

### DIFF
--- a/app/src/main/java/com/mozilla/hackathon/kiboko/App.java
+++ b/app/src/main/java/com/mozilla/hackathon/kiboko/App.java
@@ -24,7 +24,7 @@ public class App extends Application {
         context = getApplicationContext();
         PACKAGE_NAME = context.getPackageName();
         // Battery receiver - Catches battery low system event
-         context.registerReceiver(new DSOBatteryReceiver(), new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        // context.registerReceiver(new DSOBatteryReceiver(), new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
     }
 
     public static Context getContext() {


### PR DESCRIPTION
Remove the battery received since there's no tutorial content for it.